### PR TITLE
Bugfix: typo in property name option(s)

### DIFF
--- a/toggle-btn.vue
+++ b/toggle-btn.vue
@@ -103,8 +103,8 @@ export default {
 			}
 		},
 		setBindedProp(key, propToBind) {
-			if (this.option[key][propToBind]) {
-				this[key][propToBind] = this.option[key][propToBind];
+			if (this.options[key][propToBind]) {
+				this[key][propToBind] = this.options[key][propToBind];
 			}
 		},
 		setNewToggleState() {


### PR DESCRIPTION
Due to "option" instead of "options" it is was not possible to pass custom configuration from template via :options="..."